### PR TITLE
Provide accessors for the underling arrays of domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,19 @@ function isDisposable(email) {
     return disposable.indexOf(domain) !== -1;
 }
 
+// Return a copy of the full list domains serving free email accounts, including disposable email accounts
+function freeList() {
+  return free.slice();
+}
+
+// Return a copy of the full list of domains serving disposable email accounts
+function disposableList() {
+  return disposable.slice();
+}
+
 module.exports = {
     isFree: isFree,
-    isDisposable: isDisposable
+    isDisposable: isDisposable,
+    freeList: freeList,
+    disposableList: disposableList
 };

--- a/test/test.js
+++ b/test/test.js
@@ -30,3 +30,33 @@ test('gmail.com should not be disposable', function(t) {
     t.plan(1);
     t.equal(freemail.isDisposable('smith@gmail.com'), false);
 });
+
+test('freeList() should return an array', function(t) {
+    t.plan(1);
+    t.equal(Array.isArray(freemail.freeList()), true);
+});
+
+test('freeList() should return an array containing gmail.com', function(t) {
+    t.plan(1);
+    t.notEqual(freemail.freeList().indexOf('gmail.com'), -1);
+});
+
+test('freeList() should return an array containing mailinater.com', function(t) {
+    t.plan(1);
+    t.notEqual(freemail.freeList().indexOf('mailinater.com'), -1);
+});
+
+test('disposableList() should return an array', function(t) {
+    t.plan(1);
+    t.equal(Array.isArray(freemail.disposableList()), true);
+});
+
+test('disposableList() should return an array containing mailinater.com', function(t) {
+    t.plan(1);
+    t.notEqual(freemail.disposableList().indexOf('mailinater.com'), -1);
+});
+
+test('disposableList() should return an array not containing gmail.com', function(t) {
+    t.plan(1);
+    t.equal(freemail.disposableList().indexOf('gmail.com'), -1);
+});


### PR DESCRIPTION
An application might want to load a database with the domains,
and then do a database lookup for each test of an email address,
making it possible for DevOps to update the list on the fly
without deploying a new release.

These new accessor methods make it possible for an application to take
advantage of this module to seed the database.